### PR TITLE
Ruby 1.8 doesn't have Random class

### DIFF
--- a/lib/kage/connection.rb
+++ b/lib/kage/connection.rb
@@ -68,7 +68,7 @@ module Kage
       self.comm_inactivity_timeout = server.client_timeout
       self.master_backend = server.master
 
-      @session_id = "%016x" % (defined?(Random) ? Random : Kernel).rand(2**64)
+      @session_id = "%016x" % rand(2**64)
       info "New connection"
 
       @callbacks = server.callbacks


### PR DESCRIPTION
Random class is provided by only  ruby 1.9 later. but my project uses ruyb 1.8 yet. Please accepte this PR.

I understand that ruby 1.8 is discontinued to support in Jun 2013. If this PR rejected, I'll use to my forked version.

Thanks.
