### PR TITLE
Fix copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012 Tatsuhiko Miyagawa
+Copyright (c) 2012-2014 Tatsuhiko Miyagawa
 
 MIT License
 


### PR DESCRIPTION
Fix outdated copyright year (update to 2014)
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info