### PR TITLE
Fix no method error with HTTP::Parser#request_path

### DIFF
--- a/lib/kage/connection.rb
+++ b/lib/kage/connection.rb
@@ -88,7 +88,7 @@ module Kage
       @parser.on_headers_complete = proc do |headers|
         @request = {
           :method => @parser.http_method,
-          :path => @parser.request_path,
+          :path => URI.parse(@parser.request_url).path,
           :url => @parser.request_url,
           :headers => headers
         }


### PR DESCRIPTION
http_parser removed `request_path` method. Now, kage is broken with latest version(0.6.0) of http_parser. 
So, it's better to parse `Http::Parser#request_url` with `URI.parse`.
Do you think about it?

[links]
- https://github.com/tmm1/http_parser.rb/pull/15
- https://github.com/igrigorik/em-websocket/blob/master/lib/em-websocket/handshake.rb#L88
